### PR TITLE
Makefile changes to address floating point instability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,9 @@ else
 	CXXFLAGS+=-O3
 endif
 
-CXXFLAGS+=-Wall -fPIC -I$(STLPORT_INC) -std=c++0x
+
+
+CXXFLAGS+=-Wall -Wfloat-equal -ffloat-store -fPIC -I$(STLPORT_INC) -std=c++0x
 
 # Set runpath instead of relying on LD_LIBRARY_PATH
 LDFLAGS=-L./ -L$(STLPORT_LIB) -Wl,-rpath -Wl,$(STLPORT_LIB)


### PR DESCRIPTION
Added two compiler flags:

-ffloat-store

This prevents 80-bit floats from being stored in 64-bit registers and
restores simtools behaviour on float rounding to be as it was in
version 1.8

-Wfloat-equal

This warns if floats are compared with == or != which are a potential
source of instability