### PR TITLE
Performance improvement for Illuminus format conversion

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -348,10 +348,9 @@ void Commander::commandIlluminus(string infile, string outfile, string manfile, 
   for (int n = start_pos; n <= end_pos; n++) {
     *outStream << manifest->snps[n].name << "\t" << manifest->snps[n].position << "\t" << manifest->snps[n].snp[0] << manifest->snps[n].snp[1];
     for (unsigned int i = 0; i < sim->numSamples; i++) {
-      vector<float> s = SampleArray[i];
       for (unsigned int j=0; j < sim->numChannels; j++) {
-	int k = (n - start_pos) * sim->numChannels + j;
-	*outStream << '\t' << setw(7) << std::fixed << setprecision(3) << s[k];
+        int k = (n - start_pos) * sim->numChannels + j;
+        *outStream << '\t' << setw(7) << std::fixed << setprecision(3) << SampleArray[i][k];
       }
     }
     *outStream << endl;


### PR DESCRIPTION
Avoids allocating a new vector in this nested loop. Runtime for 1 sample is reduced from 7 min 3 sec to just 3 sec (most time was spent in memcpy).