### PR TITLE
Fixed a missing closing brace at the end of Gtc::json_dump

### DIFF
--- a/Gtc.cpp
+++ b/Gtc.cpp
@@ -217,6 +217,7 @@ string Gtc::json_dump(void)
 	  << "\"imaging_user\":\"" << imagingUser << "\""
 	  << "}";
 	return s.str();
+}
 
 void Gtc::normalizeIntensity(double x_raw, double y_raw,
                              double &x_norm, double &y_norm,


### PR DESCRIPTION
Fixed a missing closing brace at the end of Gtc::json_dump which appears to have been deleted during a merge.